### PR TITLE
Add responseMsg function for generating Messaging Twiml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 cabal.sandbox.config
 dist
 test/examples/*.txt
+.stack-work

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,1 +1,2 @@
 Mark Andrus Roberts <markandrusroberts@gmail.com>
+Sibi Prabakaran <sibi@psibi.in>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.2.1
+=======
+
+* Add `responseMsg` function for building responses which contain
+  `<Message>` in it.
+
 0.2.0.1 (August 13, 2017)
 =========================
 

--- a/src/Text/XML/Twiml.hs
+++ b/src/Text/XML/Twiml.hs
@@ -10,6 +10,7 @@ module Text.XML.Twiml
   ( MessagingTwiml(..)
   , VoiceTwiml(..)
   , response
+  , responseMsg
   , module X
   ) where
 

--- a/src/Text/XML/Twiml.hs
+++ b/src/Text/XML/Twiml.hs
@@ -10,7 +10,8 @@ module Text.XML.Twiml
   ( MessagingTwiml(..)
   , VoiceTwiml(..)
   , response
-  , responseMsg
+  , voiceResponse
+  , messagingResponse
   , module X
   ) where
 

--- a/src/Text/XML/Twiml/Internal/Twiml.hs
+++ b/src/Text/XML/Twiml/Internal/Twiml.hs
@@ -45,6 +45,7 @@ module Text.XML.Twiml.Internal.Twiml
   , TwimlLike
   , TwimlLike'
   , response
+  , responseMsg
     -- ** Nouns
   , DialNoun(..)
   , DialNounF(..)
@@ -697,3 +698,7 @@ type TwimlLike' f = IxFree f
 
 response :: IxFree VoiceVerbsF i Void -> VoiceTwiml
 response = VoiceTwiml
+
+responseMsg :: IxFree MessagingVerbsF i Void -> MessagingTwiml
+responseMsg = MessagingTwiml
+

--- a/src/Text/XML/Twiml/Internal/Twiml.hs
+++ b/src/Text/XML/Twiml/Internal/Twiml.hs
@@ -45,7 +45,8 @@ module Text.XML.Twiml.Internal.Twiml
   , TwimlLike
   , TwimlLike'
   , response
-  , responseMsg
+  , voiceResponse
+  , messagingResponse
     -- ** Nouns
   , DialNoun(..)
   , DialNounF(..)
@@ -696,9 +697,11 @@ type TwimlLike f i = TwimlLike' f '[i]
 
 type TwimlLike' f = IxFree f
 
+voiceResponse :: IxFree VoiceVerbsF i Void -> VoiceTwiml
+voiceResponse = VoiceTwiml
+
+messagingResponse :: IxFree MessagingVerbsF i Void -> MessagingTwiml
+messagingResponse = MessagingTwiml
+
 response :: IxFree VoiceVerbsF i Void -> VoiceTwiml
-response = VoiceTwiml
-
-responseMsg :: IxFree MessagingVerbsF i Void -> MessagingTwiml
-responseMsg = MessagingTwiml
-
+response = voiceResponse


### PR DESCRIPTION
Allows programs like this to compile:

```
example :: MessagingTwiml
example =
  responseMsg $
  do message "Store Location: 123 Easy St." def
     end
  where
    Twiml.Syntax {..} = def
```